### PR TITLE
Remove hardcoded select sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 <body>
 <div class="content">
     <div class="left_block block_1">
-        <select id="schoolSelect" name="school" onchange="school=this.value;populatePre(school,sport);" size="100"
+        <select id="schoolSelect" name="school" onchange="school=this.value;populatePre(school,sport);"
                 style="max-height: 100%; overflow-y: scroll;">
             <option value="all">all schools</option>
             <option value="">--------------------------</option>
@@ -41,7 +41,7 @@
     </div>
 
     <div class="block_2">
-        <select id="sportSelect" name="sport" onchange="sport=this.value;populatePre(school,sport);" size="9">
+        <select id="sportSelect" name="sport" onchange="sport=this.value;populatePre(school,sport);">
             <option value="all">all sports</option>
             <option value="">--------------------</option>
             <option value="BASEBALL">BASEBALL</option>

--- a/script.js
+++ b/script.js
@@ -31,14 +31,21 @@ if (matchMedia) {
     WidthChange(mq);
 }
 
+function setSelectSize(select) {
+    select.size = Math.max(select.options.length, 1);
+}
+
 // media query change
 function WidthChange(mq) {
+    var schoolSelect = document.getElementById("schoolSelect");
+    var sportSelect = document.getElementById("sportSelect");
+
     if (mq.matches) { // window width is less than 641px
-        document.getElementById("schoolSelect").size = "1";
-        document.getElementById("sportSelect").size = "1";
+        schoolSelect.size = "1";
+        sportSelect.size = "1";
     } else {
-        document.getElementById("schoolSelect").size = "100";
-        document.getElementById("sportSelect").size = "9";
+        setSelectSize(schoolSelect);
+        setSelectSize(sportSelect);
     }
 }
 
@@ -48,5 +55,6 @@ $.get("backend/GetTables/WPIAL schools.txt", function( data ) {
     $.trim(data).split('\n').forEach(function (line) {
         $('#schoolSelect').append(new Option(line, line));
     });
+    WidthChange(window.matchMedia("(max-width: 641px)"));
 });
 populatePre(school, sport);


### PR DESCRIPTION
This PR is submitted as a truthful AI-assisted experiment for the bounty/help-wanted workflow.

Closes #8.

## What changed

- Removed the hardcoded `size="100"` and `size="9"` attributes from the school and sport selects.
- Added `setSelectSize(select)` so desktop select heights derive from each select's current option count.
- Re-run the sizing after the school list is loaded asynchronously.
- Preserved the existing mobile behavior that collapses both selects to `size = 1` below the existing 641px media query.

## Verification

- Ran `node --check script.js` locally.

## Payment

If this is accepted for the bounty/payment flow linked from PatMyron/.github#1, PayPal payout can go to: https://www.paypal.com/paypalme/whathestock